### PR TITLE
Set /tmp as ephemeral emptydir to prevent writing into overlayfs

### DIFF
--- a/charts/otf/Chart.yaml
+++ b/charts/otf/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/otf/templates/deployment.yaml
+++ b/charts/otf/templates/deployment.yaml
@@ -96,13 +96,17 @@ spec:
               port: 8080
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{ if .Values.CACerts }}
           volumeMounts:
+          - name: tmp
+            mountPath: /tmp
+          {{ if .Values.CACerts }}
           - name: certs
             mountPath: /certs
           {{ end }}
-      {{ if .Values.CACerts }}
       volumes:
+        - name: tmp
+          emptyDir:
+      {{ if .Values.CACerts }}
         - name: certs
           configMap:
             name: certs


### PR DESCRIPTION
Bumped the chart version to 0.2.0 since I belive this is a feature for me, feel free to change as you wish.