### PR TITLE
feat: added no_proxy and expanded proxy to multiple casing variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Note: you should only use this for testing purposes.
 | logging.verbosity | int | `0` | Logging verbosity, the higher the number the more verbose the logs. See [docs](https://docs.otf.ninja/latest/config/flags/#-v). |
 | maxConfigSize | string | `""` | Max config upload size in bytes. See [docs](https://docs.otf.ninja/latest/config/flags/#-max-config-size). |
 | nameOverride | string | `""` |  |
+| no_proxy | string | `nil` | Specify hosts for which outbound connections should not use the proxy. |
 | nodeSelector | object | `{}` |  |
 | oidc.clientID | string | `""` | OIDC client ID. See [docs](https://docs.otf.ninja/latest/auth/providers/oidc/). |
 | oidc.clientSecretFromSecret | object | `nil` | Source OIDC client secret from a k8s secret. See [docs](https://docs.otf.ninja/latest/auth/providers/oidc/). |
@@ -81,7 +82,7 @@ Note: you should only use this for testing purposes.
 | podAnnotations | object | `{}` | Add annotations to otfd pod |
 | podSecurityContext | object | `{}` | Set security context for otfd pod |
 | postgres.enabled | bool | `false` | Install postgres chart dependency. |
-| proxy | string | `nil` | Specify an https proxy for outbound connections. |
+| proxy | string | `nil` | Specify an http(s) proxy for outbound connections. |
 | replicaCount | int | `1` | Number of otfd nodes in cluster |
 | resources | object | `{}` |  |
 | sandbox | bool | `false` | Enable sandboxing of terraform apply - note, this will run pods as privileged |

--- a/charts/otf/templates/deployment.yaml
+++ b/charts/otf/templates/deployment.yaml
@@ -106,6 +106,18 @@ spec:
             {{ with .Values.proxy -}}
             - name: HTTPS_PROXY
               value: "{{ . }}"
+            - name: HTTP_PROXY
+              value: "{{ . }}"
+            - name: https_proxy
+              value: "{{ . }}"
+            - name: http_proxy
+              value: "{{ . }}"
+            {{- end }}
+            {{ with .Values.no_proxy -}}
+            - name: NO_PROXY
+              value: "{{ . }}"
+            - name: no_proxy
+              value: "{{ . }}"
             {{- end }}
             {{ with .Values.siteAdmins -}}
             - name: OTF_SITE_ADMINS

--- a/charts/otf/values.yaml
+++ b/charts/otf/values.yaml
@@ -152,8 +152,10 @@ caCerts:
   # -- Specify individual items in secret containing CA certificates. Use the [KeyToPath](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#keytopath-v1-core) schema for each item. If unspecified, all items are mounted from the secret.
   secretItems: []
 
-# -- Specify an https proxy for outbound connections.
+# -- Specify an http(s) proxy for outbound connections.
 proxy:
+# -- Specify hosts for which outbound connections should not use the proxy.
+no_proxy:
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR adds a no_proxy environment variable, and expands the https_proxy env to the [common permutations](https://unix.stackexchange.com/questions/212894/whats-the-right-format-for-the-http-proxy-environment-variable-caps-or-no-ca)