### PR TITLE
feat: added support for user defined env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Note: you should only use this for testing purposes.
 | database | string | `""` | Postgres connection string |
 | databasePasswordFromSecret | object | `nil` | Source database password from a secret |
 | databaseUsernameFromSecret | object | `nil` | Source database username from a secret |
+| extraEnvs | list | `[]` | Extra environment variables to be passed to the deployment. |
 | fullnameOverride | string | `""` |  |
 | github.clientID | string | `""` | Github OAuth client ID. See [docs](https://docs.otf.ninja/latest/config/flags/#-github-client-id). |
 | github.clientSecret | string | `""` | Github OAuth client secret. See [docs](https://docs.otf.ninja/latest/config/flags/#-github-client-secret). |

--- a/charts/otf/templates/deployment.yaml
+++ b/charts/otf/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           env:
+{{- range $key, $value := .Values.extraEnvs }}
+            - name: {{ $key }}
+              value: {{ $value }}
+{{- end }}
             - name: OTF_HOSTNAME
               value: "{{ .Values.hostname }}"
             {{- with .Values.logging }}

--- a/charts/otf/values.yaml
+++ b/charts/otf/values.yaml
@@ -43,6 +43,9 @@ databasePasswordFromSecret:
   # key within secret containing password
   # key: ""
 
+# -- Extra environment variables to be passed to the deployment.
+extraEnvs: []
+
 # -- Cryptographic secret. Must be a hex-encoded 16-byte string. See [docs](https://docs.otf.ninja/latest/config/flags/#-secret).
 secret: ""
 


### PR DESCRIPTION
This PR adds an extraEnvs variables for allowing chart consumers to add whatever env vars they want. This is useful for configuring flags that aren't otherwise exported, such as disabling organization creation. 