### PR TITLE
Fix maxConfigSize parsing

### DIFF
--- a/charts/otf/templates/deployment.yaml
+++ b/charts/otf/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
               value: {{ .Values.siteToken }}
             {{ if .Values.maxConfigSize }}
             - name: OTF_MAX_CONFIG_SIZE
-              value: {{ .Values.maxConfigSize }}
+              value: "{{ .Values.maxConfigSize }}"
             {{ end }}
             - name: OTF_GITHUB_CLIENT_ID
               value: {{ .Values.github.clientID }}


### PR DESCRIPTION
The maxConfigSize needs to be a string for a kubernetes deployment, presenting it as a number causes parsing errors in GKE via terraform.

