### PR TITLE
fix the default github and gitlab hostnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # otf-charts
 
-![Version: 0.3.9](https://img.shields.io/badge/Version-0.3.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.3](https://img.shields.io/badge/AppVersion-0.2.3-informational?style=flat-square)
+![Version: 0.3.10](https://img.shields.io/badge/Version-0.3.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2.3](https://img.shields.io/badge/AppVersion-0.2.3-informational?style=flat-square)
 
 [OTF](https://github.com/leg100/otf) Helm charts.
 
@@ -53,10 +53,10 @@ Note: you should only use this for testing purposes.
 | fullnameOverride | string | `""` |  |
 | github.clientID | string | `""` | Github OAuth client ID. See [docs](https://docs.otf.ninja/latest/config/flags/#-github-client-id). |
 | github.clientSecret | string | `""` | Github OAuth client secret. See [docs](https://docs.otf.ninja/latest/config/flags/#-github-client-secret). |
-| github.hostname | string | `"https://github.com"` | Github hostname to use for all interactions with Github. |
+| github.hostname | string | `"github.com"` | Github hostname to use for all interactions with Github. |
 | gitlab.clientID | string | `""` | Gitlab OAuth client ID. See [docs](https://docs.otf.ninja/latest/config/flags/#-gitlab-client-id). |
 | gitlab.clientSecret | string | `""` | Gitlab OAuth client secret. See [docs](https://docs.otf.ninja/latest/config/flags/#-gitlab-client-secret). |
-| gitlab.hostname | string | `"https://gitlab.com"` | Gitlab hostname to use for all interactions with Gitlab. |
+| gitlab.hostname | string | `"gitlab.com"` | Gitlab hostname to use for all interactions with Gitlab. |
 | google.audience | string | `""` | The Google JWT audience claim for validation. Validation is skipped if empty. See [docs](https://docs.otf.ninja/latest/config/flags/#-google-jwt-audience). |
 | hostname | string | `""` | Set client-accessible hostname. See [docs](https://docs.otf.ninja/latest/config/flags/#-hostname). |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/otf/Chart.yaml
+++ b/charts/otf/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.9
+version: 0.3.10
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/otf/values.yaml
+++ b/charts/otf/values.yaml
@@ -78,7 +78,7 @@ github:
   # -- Github OAuth client secret. See [docs](https://docs.otf.ninja/latest/config/flags/#-github-client-secret).
   clientSecret: ""
   # -- Github hostname to use for all interactions with Github.
-  hostname: "https://github.com"
+  hostname: "github.com"
 
 gitlab:
   # -- Gitlab OAuth client ID. See [docs](https://docs.otf.ninja/latest/config/flags/#-gitlab-client-id).
@@ -86,7 +86,7 @@ gitlab:
   # -- Gitlab OAuth client secret. See [docs](https://docs.otf.ninja/latest/config/flags/#-gitlab-client-secret).
   clientSecret: ""
   # -- Gitlab hostname to use for all interactions with Gitlab.
-  hostname: "https://gitlab.com"
+  hostname: "gitlab.com"
 
 google:
   # -- The Google JWT audience claim for validation. Validation is skipped if empty. See [docs](https://docs.otf.ninja/latest/config/flags/#-google-jwt-audience).


### PR DESCRIPTION
apologies - I believe that I screwed up the default hostnames for gitlab and github in my PR!

this removes the prepended `https://` to each of them in the default values.

I've also run:
- `make bump`
- `make readme`

as a part of this PR